### PR TITLE
Fix: export broken in routes.js (missing bracket)

### DIFF
--- a/src/lib/routes.js
+++ b/src/lib/routes.js
@@ -79,6 +79,7 @@ const routes = {
         title: 'Testing: cerere-preview',
         requiresAuth: false,
         route: '/home/testing/cerere-preview',
+    },
     'pagina-confirmare-decizie-admin': {
         title: 'Pagina confirmare decizie - ADMIN',
         requiresAuth: true,


### PR DESCRIPTION
La rezolvarea conflictului, am sters o paranteza din gresela(am rezolvat conflictul direct de pe git), si a picat build ul.